### PR TITLE
Update Dockerfile string header

### DIFF
--- a/voltronic-inverters/Dockerfile
+++ b/voltronic-inverters/Dockerfile
@@ -37,6 +37,8 @@ RUN rm -rf repo
 COPY run.sh /run.sh
 RUN chmod a+x /run.sh
 
+RUN sed -i '1i#include <string>' /opt/inverter-cli/inverter.h
+
 # Build the inverter CLI
 RUN cd /opt/inverter-cli && \
     mkdir bin && \


### PR DESCRIPTION
Hello,

I'm submitting this PR to fix a compilation error encountered when building on modern environments (such as Raspberry Pi 5 with GCC 13+ / Debian Bookworm).

Problem: The build fails because std::string is used in inverter.h but the <string> header is not explicitly included. In newer compiler versions, certain standard headers are no longer included transitively, leading to errors like: error: 'string' in namespace 'std' does not name a type

Solution: Explicitly add #include <string> at the beginning of inverter.h.

This change ensures compatibility with newer toolchains while maintaining backward compatibility with older ones.